### PR TITLE
Add Instructions directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Local instructions artifacts
+Instructions/
+instructions/


### PR DESCRIPTION
### Motivation
- Prevent local instruction artifacts from being tracked by git by ignoring the `Instructions/` and `instructions/` directories.

### Description
- Add a root `.gitignore` file containing a comment and entries for `Instructions/` and `instructions/` to exclude those folders from version control.

### Testing
- Verified `git status --short` showed only `.gitignore` as new and committed the change with message `Add Instructions folder to gitignore`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7a0602988330b6ece0112dd9270d)