### PR TITLE
Add mandatory append-only agent changelog requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENT REQUIREMENTS
+
+## Change log rule (mandatory)
+For every major change you complete in this repository:
+1. Go to `Instructions/Done.txt`.
+2. Append a new line describing the major change.
+3. Never remove or modify previous entries in `Instructions/Done.txt`.
+
+This is an append-only change log for agents (including AI agents and Codex).

--- a/Instructions/Done.txt
+++ b/Instructions/Done.txt
@@ -1,1 +1,1 @@
-
+- Added a mandatory agent requirement in `AGENTS.md` instructing all agents/Codex to append each major change to `Instructions/Done.txt` as an append-only log.


### PR DESCRIPTION
### Motivation
- Ensure every major change made by agents (including Codex) is recorded persistently in a single place. 
- Create an append-only, tamper-resistant workflow so prior entries are never removed or modified.

### Description
- Add `AGENTS.md` with a mandatory rule instructing agents to append each major change to `Instructions/Done.txt` and never delete or modify prior entries. 
- Update `Instructions/Done.txt` with an initial changelog entry describing this new requirement. 
- Affected files: added `AGENTS.md` and modified `Instructions/Done.txt`.

### Testing
- Ran `git status --short` to verify repository state and it completed successfully. 
- Ran `git show --stat --oneline HEAD` to confirm the change was recorded and it completed successfully. 
- Printed and inspected `AGENTS.md` and `Instructions/Done.txt` with `nl -ba` to verify the new content and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7be9c5a08330b752233074050e75)