### PR TITLE
Add programs for source extraction, duplicate Mod_ renaming, and output validation

### DIFF
--- a/Instructions/Done.txt
+++ b/Instructions/Done.txt
@@ -1,1 +1,2 @@
 - Added a mandatory agent requirement in `AGENTS.md` instructing all agents/Codex to append each major change to `Instructions/Done.txt` as an append-only log.
+- Added three scripts in `programs/` for source extraction, duplicate `Mod_` folder renaming with random 5-char suffix, and output structure validation.

--- a/programs/check_source_and_extract_to_output.py
+++ b/programs/check_source_and_extract_to_output.py
@@ -1,0 +1,130 @@
+"""Task 1:
+Check source mod folders, then extract/copy the correct contents into output.
+
+This script mirrors the root `First.py` flow but with command-line options so it can be
+used from the `programs` folder directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+BUGGED_MARKERS = {"ModProject", "debug"}
+NESTED_PAYLOAD_FOLDER = "debug"
+
+
+def transfer_item(src: Path, dst: Path, do_move: bool, overwrite_files: bool) -> None:
+    if src.is_dir():
+        if do_move:
+            dst.mkdir(parents=True, exist_ok=True)
+            for child in src.iterdir():
+                transfer_item(child, dst / child.name, do_move=True, overwrite_files=overwrite_files)
+            try:
+                src.rmdir()
+            except OSError:
+                pass
+        else:
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+        return
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        if overwrite_files:
+            dst.unlink()
+        else:
+            print(f"  [SKIP] File exists: {dst}")
+            return
+
+    if do_move:
+        shutil.move(str(src), str(dst))
+    else:
+        shutil.copy2(src, dst)
+
+
+def transfer_contents(src_dir: Path, dst_dir: Path, do_move: bool, overwrite_files: bool) -> None:
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    for item in src_dir.iterdir():
+        transfer_item(item, dst_dir / item.name, do_move, overwrite_files)
+
+
+def is_bugged_mod_folder(mod_folder: Path) -> bool:
+    names = {p.name for p in mod_folder.iterdir() if p.is_dir()}
+    return BUGGED_MARKERS.issubset(names)
+
+
+def run(source_root: Path, output_root: Path, do_move: bool, overwrite_files: bool) -> int:
+    if not source_root.exists() or not source_root.is_dir():
+        print(f"[ERROR] source root does not exist or is not a folder: {source_root}")
+        return 1
+
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    total = 0
+    fixed = 0
+    normal = 0
+    skipped = 0
+
+    for mod_folder in source_root.iterdir():
+        if not mod_folder.is_dir():
+            continue
+
+        total += 1
+        out_mod_folder = output_root / mod_folder.name
+        out_mod_folder.mkdir(parents=True, exist_ok=True)
+
+        try:
+            if is_bugged_mod_folder(mod_folder):
+                nested = mod_folder / NESTED_PAYLOAD_FOLDER
+                if nested.exists() and nested.is_dir():
+                    print(f"[FIX ] {mod_folder.name} -> extracting contents of '{NESTED_PAYLOAD_FOLDER}'")
+                    transfer_contents(nested, out_mod_folder, do_move, overwrite_files)
+                    fixed += 1
+                else:
+                    print(f"[WARN] {mod_folder.name} has bug markers but missing '{NESTED_PAYLOAD_FOLDER}'")
+                    skipped += 1
+            else:
+                print(f"[COPY] {mod_folder.name} -> already normal (or not matching bug markers)")
+                transfer_contents(mod_folder, out_mod_folder, do_move, overwrite_files)
+                normal += 1
+        except Exception as exc:
+            print(f"[ERR ] {mod_folder.name}: {exc}")
+            skipped += 1
+
+    mode = "MOVE" if do_move else "COPY"
+    print("\n=== DONE ===")
+    print(f"Mode: {mode}")
+    print(f"Total mod folders: {total}")
+    print(f"Fixed bugged folders: {fixed}")
+    print(f"Normal copied folders: {normal}")
+    print(f"Skipped/errors: {skipped}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check source mod folders and extract/copy into output.")
+    parser.add_argument("source_root", type=Path, help="Path to source mod folder.")
+    parser.add_argument("output_root", type=Path, help="Path to output mod folder.")
+    parser.add_argument("--move", action="store_true", help="Move files instead of copying.")
+    parser.add_argument(
+        "--no-overwrite",
+        action="store_true",
+        help="Do not overwrite files if they already exist in output.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    return run(
+        source_root=args.source_root,
+        output_root=args.output_root,
+        do_move=args.move,
+        overwrite_files=not args.no_overwrite,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/programs/rename_duplicate_mod_folders.py
+++ b/programs/rename_duplicate_mod_folders.py
@@ -1,0 +1,94 @@
+"""Task 2:
+Find duplicate Mod_* folders under output and rename extra copies with a random suffix.
+
+Duplicate detection is done inside each parent directory. If multiple folders share the same
+base name after stripping a trailing `_<5 alnum chars>` suffix, all but the first are renamed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import re
+import string
+from pathlib import Path
+
+MOD_PREFIX = "Mod_"
+SUFFIX_RE = re.compile(r"^(?P<base>.+)_([A-Za-z0-9]{5})$")
+ALNUM = string.ascii_letters + string.digits
+
+
+def random_suffix(length: int = 5) -> str:
+    return "".join(random.choices(ALNUM, k=length))
+
+
+def normalized_key(name: str) -> str:
+    if not name.startswith(MOD_PREFIX):
+        return name
+
+    match = SUFFIX_RE.match(name)
+    if not match:
+        return name
+
+    return match.group("base")
+
+
+def unique_renamed_path(folder: Path) -> Path:
+    base_name = folder.name
+    while True:
+        candidate = folder.with_name(f"{base_name}_{random_suffix(5)}")
+        if not candidate.exists():
+            return candidate
+
+
+def rename_duplicates_in_parent(parent: Path) -> int:
+    renamed = 0
+    groups: dict[str, list[Path]] = {}
+
+    for child in parent.iterdir():
+        if child.is_dir() and child.name.startswith(MOD_PREFIX):
+            key = normalized_key(child.name)
+            groups.setdefault(key, []).append(child)
+
+    for _, folders in groups.items():
+        if len(folders) < 2:
+            continue
+
+        folders.sort(key=lambda p: p.name)
+        for duplicate in folders[1:]:
+            new_path = unique_renamed_path(duplicate)
+            duplicate.rename(new_path)
+            print(f"[RENAME] {duplicate} -> {new_path.name}")
+            renamed += 1
+
+    return renamed
+
+
+def scan_output(output_root: Path) -> int:
+    if not output_root.exists() or not output_root.is_dir():
+        print(f"[ERROR] output root does not exist or is not a folder: {output_root}")
+        return 1
+
+    total_renamed = 0
+    for parent in [output_root, *[p for p in output_root.rglob("*") if p.is_dir()]]:
+        total_renamed += rename_duplicates_in_parent(parent)
+
+    print(f"\n=== DONE ===\nTotal renamed folders: {total_renamed}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Rename duplicate Mod_* folders by appending random 5-char alnum suffixes."
+    )
+    parser.add_argument("output_root", type=Path, help="Path to output root directory.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    return scan_output(args.output_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/programs/validate_output_structure.py
+++ b/programs/validate_output_structure.py
@@ -1,0 +1,62 @@
+"""Task 3:
+Check whether output folder structure is proper based on root `First.py` expectations.
+
+Rule used from `First.py`:
+- A folder is considered bugged when it contains BOTH `ModProject` and `debug` directories.
+In output, such a structure should generally not remain after extraction.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+BUGGED_MARKERS = {"ModProject", "debug"}
+
+
+def has_bugged_structure(folder: Path) -> bool:
+    names = {p.name for p in folder.iterdir() if p.is_dir()}
+    return BUGGED_MARKERS.issubset(names)
+
+
+def validate_output(output_root: Path) -> int:
+    if not output_root.exists() or not output_root.is_dir():
+        print(f"[ERROR] output root does not exist or is not a folder: {output_root}")
+        return 1
+
+    checked = 0
+    invalid = 0
+
+    for mod_folder in output_root.iterdir():
+        if not mod_folder.is_dir():
+            continue
+
+        checked += 1
+        if has_bugged_structure(mod_folder):
+            print(
+                f"[BAD ] {mod_folder.name}: still contains both '{sorted(BUGGED_MARKERS)[0]}' "
+                f"and '{sorted(BUGGED_MARKERS)[1]}'"
+            )
+            invalid += 1
+        else:
+            print(f"[OK  ] {mod_folder.name}")
+
+    print("\n=== DONE ===")
+    print(f"Checked folders: {checked}")
+    print(f"Invalid folders: {invalid}")
+    return 0 if invalid == 0 else 2
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate output folder structure.")
+    parser.add_argument("output_root", type=Path, help="Path to output root directory.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    return validate_output(args.output_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide standalone CLI utilities to automate the mod-folder fixes implemented in `First.py` so they can be run from `programs/` as discrete tasks.
- Ensure output folders do not contain duplicate `Mod_` directories or leftover bugged structures after extraction.
- Make the behavior configurable (move vs copy, overwrite control) and deterministic for integration into pipelines.
- Record the change in the repository append-only changelog per agent requirements by updating `Instructions/Done.txt`.

### Description
- Added `programs/check_source_and_extract_to_output.py` which mirrors `First.py` but exposes a CLI and supports `--move` and `--no-overwrite` options while preserving the `BUGGED_MARKERS`/`NESTED_PAYLOAD_FOLDER` logic.
- Added `programs/rename_duplicate_mod_folders.py` which scans `output_root` and renames duplicate `Mod_` folders by appending a random 5-character alphanumeric suffix, normalizing existing `_xxxxx` suffixes when grouping duplicates.
- Added `programs/validate_output_structure.py` which checks each output mod folder for the bugged marker pair (`ModProject` and `debug`) and returns a non-zero status when invalid folders are found.
- Appended a changelog entry to `Instructions/Done.txt` describing the three new scripts as required by repository agent rules.

### Testing
- Compiled all modified/new Python files with `python -m py_compile programs/check_source_and_extract_to_output.py programs/rename_duplicate_mod_folders.py programs/validate_output_structure.py First.py` and the compilation succeeded.
- Ran each script's help to verify CLI parsing with `python programs/check_source_and_extract_to_output.py --help`, `python programs/rename_duplicate_mod_folders.py --help`, and `python programs/validate_output_structure.py --help`, and each produced the expected usage output.
- Verified the changelog update by appending the descriptive line to `Instructions/Done.txt` and committing the change, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7d453294833094fcf5b036b3f8a0)