### PR TITLE
Add temp-dev protection rule for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,4 @@ This is an append-only change log for agents (including AI agents and Codex).
 - A root-level folder named `temp-dev/` is available for placeholder/testing files.
 - If a task is applicable to the repository programs, use files in `temp-dev/` as needed and verify the related program flow runs smoothly.
 - If a task does not involve repository programs (for example: updating docs like `README`/`AGENTS.md`), program execution is optional and does not need to be run.
+- Never modify folders or files inside `temp-dev/`, except for `temp-dev/.gitkeep`.

--- a/Instructions/Done.txt
+++ b/Instructions/Done.txt
@@ -1,3 +1,4 @@
 - Added a mandatory agent requirement in `AGENTS.md` instructing all agents/Codex to append each major change to `Instructions/Done.txt` as an append-only log.
 - Added three scripts in `programs/` for source extraction, duplicate `Mod_` folder renaming with random 5-char suffix, and output structure validation.
 - Created root-level temp-dev/ folder for placeholder/testing files and updated AGENTS.md with guidance on when to run repository programs.
+- Updated `AGENTS.md` to explicitly forbid modifying files/folders inside `temp-dev/` except `temp-dev/.gitkeep`.


### PR DESCRIPTION
### Motivation
- Prevent accidental modification of example/test data in `temp-dev/` during agent tasks and program runs by making a clear, enforceable rule.

### Description
- Added a rule to `AGENTS.md` that forbids modifying any files or folders inside `temp-dev/` except `temp-dev/.gitkeep`, and appended an entry to `Instructions/Done.txt` documenting the change.

### Testing
- Validated the repository tools by copying `temp-dev/` to a disposable workspace and running `python3 programs/check_source_and_extract_to_output.py test-work/source test-work/output`, `python3 programs/rename_duplicate_mod_folders.py test-work/output`, and `python3 programs/validate_output_structure.py test-work/output`, which completed successfully (3 folders processed, 2 bugged folders fixed, 0 renames, 0 invalid folders).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d807cc7e48330bacca3d15da820c3)