### PR TITLE
Overhaul initialization flow and replace Run Program.bat with interactive Setup.bat

### DIFF
--- a/Instructions/Done.txt
+++ b/Instructions/Done.txt
@@ -4,3 +4,4 @@
 - Updated `AGENTS.md` to explicitly forbid modifying files/folders inside `temp-dev/` except `temp-dev/.gitkeep`.
 - Updated initilization flow to create Source/Output/programs, create README and Run Program.bat, download helper scripts into programs, and documented release v0.1.
 - Removed `RELEASE.md` and `README.txt`, and updated `README.md` with `initilization.py` download plus install/setup instructions.
+- Overhauled setup flow: replaced Run Program.bat with interactive Setup.bat, updated initilization.py to create Additional folder, refresh helper scripts, and download README.md into README.txt.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,8 @@ Direct raw URL:
    - `Source/`
    - `Output/`
    - `programs/`
-   - `Run Program.bat`
+   - `Setup.bat`
 
 ### Run the workflow
-- Windows: double-click `Run Program.bat`
-- Terminal: run
-  ```bash
-  python First.py
-  ```
+- Windows: double-click `Setup.bat` and follow each confirmation prompt.
+- The batch flow explains each step and asks for input before it continues.

--- a/Run Program.bat
+++ b/Run Program.bat
@@ -1,3 +1,0 @@
-@echo off
-python First.py
-pause

--- a/Setup.bat
+++ b/Setup.bat
@@ -1,0 +1,72 @@
+@echo off
+setlocal
+
+set "ROOT=%~dp0"
+cd /d "%ROOT%"
+
+echo [Setup] FireDragon TOM Modfix setup helper
+
+goto :step_folders
+
+:ask_to_continue
+echo.
+choice /M "Continue to next step"
+if errorlevel 2 (
+    echo [STOP] Setup cancelled by user.
+    goto :eof
+)
+exit /b 0
+
+:step_folders
+echo Next step: create required folders (Source, Output, programs, Additional).
+call :ask_to_continue || goto :eof
+for %%D in (Source Output programs Additional) do (
+    if not exist "%%D" (
+        mkdir "%%D"
+        echo [OK] Created folder: %%D
+    ) else (
+        echo [SKIP] Folder already exists: %%D
+    )
+)
+
+goto :step_helpers
+
+:step_helpers
+echo Next step: download latest helper programs into programs\ from GitHub.
+call :ask_to_continue || goto :eof
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& {
+    $ErrorActionPreference = 'Stop';
+    $base = 'https://raw.githubusercontent.com/FireDragonSlayer/FireDragon-TOM-Modfix/main/programs';
+    $files = @('check_source_and_extract_to_output.py','rename_duplicate_mod_folders.py','validate_output_structure.py');
+    foreach ($file in $files) {
+        Invoke-WebRequest -Uri ($base + '/' + $file) -OutFile (Join-Path 'programs' $file)
+        Write-Host ('[OK] Downloaded: ' + $file)
+    }
+}"
+if errorlevel 1 (
+    echo [WARN] Could not download helper scripts with PowerShell.
+) else (
+    echo [OK] Helper scripts refreshed.
+)
+
+goto :step_readme
+
+:step_readme
+echo Next step: download README.md and save it locally as README.txt.
+call :ask_to_continue || goto :eof
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& {
+    $ErrorActionPreference = 'Stop';
+    Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/FireDragonSlayer/FireDragon-TOM-Modfix/main/README.md' -OutFile 'README.txt'
+}"
+if errorlevel 1 (
+    echo [WARN] Could not download README.txt.
+) else (
+    echo [OK] README.txt downloaded.
+)
+
+goto :done
+
+:done
+echo.
+echo [DONE] Setup complete.
+pause

--- a/initilization.py
+++ b/initilization.py
@@ -3,12 +3,89 @@ from urllib.error import URLError, HTTPError
 from urllib.request import urlopen
 import shutil
 
-INITIALIZATION_VERSION = "0.1"
+INITIALIZATION_VERSION = "0.2"
+BASE_RAW_URL = "https://raw.githubusercontent.com/FireDragonSlayer/FireDragon-TOM-Modfix/main"
 PROGRAM_DOWNLOADS = {
-    "check_source_and_extract_to_output.py": "https://raw.githubusercontent.com/FireDragonSlayer/FireDragon-TOM-Modfix/main/programs/check_source_and_extract_to_output.py",
-    "rename_duplicate_mod_folders.py": "https://raw.githubusercontent.com/FireDragonSlayer/FireDragon-TOM-Modfix/main/programs/rename_duplicate_mod_folders.py",
-    "validate_output_structure.py": "https://raw.githubusercontent.com/FireDragonSlayer/FireDragon-TOM-Modfix/main/programs/validate_output_structure.py",
+    "check_source_and_extract_to_output.py": f"{BASE_RAW_URL}/programs/check_source_and_extract_to_output.py",
+    "rename_duplicate_mod_folders.py": f"{BASE_RAW_URL}/programs/rename_duplicate_mod_folders.py",
+    "validate_output_structure.py": f"{BASE_RAW_URL}/programs/validate_output_structure.py",
 }
+README_DOWNLOAD_URL = f"{BASE_RAW_URL}/README.md"
+SETUP_BAT_NAME = "Setup.bat"
+
+SETUP_BAT_CONTENT = r"""@echo off
+setlocal
+
+set "ROOT=%~dp0"
+cd /d "%ROOT%"
+
+echo [Setup] FireDragon TOM Modfix setup helper
+
+goto :step_folders
+
+:ask_to_continue
+echo.
+choice /M "Continue to next step"
+if errorlevel 2 (
+    echo [STOP] Setup cancelled by user.
+    goto :eof
+)
+exit /b 0
+
+:step_folders
+echo Next step: create required folders (Source, Output, programs, Additional).
+call :ask_to_continue || goto :eof
+for %%D in (Source Output programs Additional) do (
+    if not exist "%%D" (
+        mkdir "%%D"
+        echo [OK] Created folder: %%D
+    ) else (
+        echo [SKIP] Folder already exists: %%D
+    )
+)
+
+goto :step_helpers
+
+:step_helpers
+echo Next step: download latest helper programs into programs\ from GitHub.
+call :ask_to_continue || goto :eof
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& {
+    $ErrorActionPreference = 'Stop';
+    $base = 'https://raw.githubusercontent.com/FireDragonSlayer/FireDragon-TOM-Modfix/main/programs';
+    $files = @('check_source_and_extract_to_output.py','rename_duplicate_mod_folders.py','validate_output_structure.py');
+    foreach ($file in $files) {
+        Invoke-WebRequest -Uri ($base + '/' + $file) -OutFile (Join-Path 'programs' $file)
+        Write-Host ('[OK] Downloaded: ' + $file)
+    }
+}"
+if errorlevel 1 (
+    echo [WARN] Could not download helper scripts with PowerShell.
+) else (
+    echo [OK] Helper scripts refreshed.
+)
+
+goto :step_readme
+
+:step_readme
+echo Next step: download README.md and save it locally as README.txt.
+call :ask_to_continue || goto :eof
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& {
+    $ErrorActionPreference = 'Stop';
+    Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/FireDragonSlayer/FireDragon-TOM-Modfix/main/README.md' -OutFile 'README.txt'
+}"
+if errorlevel 1 (
+    echo [WARN] Could not download README.txt.
+) else (
+    echo [OK] README.txt downloaded.
+)
+
+goto :done
+
+:done
+echo.
+echo [DONE] Setup complete.
+pause
+"""
 
 
 def ensure_directory(path: Path) -> None:
@@ -16,49 +93,65 @@ def ensure_directory(path: Path) -> None:
     print(f"[OK] Folder ready: {path}")
 
 
-def ensure_file(path: Path, content: str = "") -> None:
-    if not path.exists():
-        path.write_text(content, encoding="utf-8")
-        print(f"[OK] File created: {path}")
-    else:
-        print(f"[SKIP] File already exists: {path}")
+def write_file(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    print(f"[OK] File written: {path}")
+
+
+def download_text(url: str, target_path: Path) -> bool:
+    try:
+        with urlopen(url, timeout=30) as response:
+            content = response.read().decode("utf-8")
+        write_file(target_path, content)
+        return True
+    except (HTTPError, URLError, TimeoutError) as error:
+        print(f"[WARN] Failed to download {target_path.name}: {error}")
+        return False
 
 
 def download_program(programs_path: Path, filename: str, url: str) -> None:
     target_path = programs_path / filename
-    try:
-        with urlopen(url, timeout=30) as response:
-            content = response.read().decode("utf-8")
-        target_path.write_text(content, encoding="utf-8")
-        print(f"[OK] Downloaded: {filename}")
-    except (HTTPError, URLError, TimeoutError) as error:
-        local_source = Path(__file__).resolve().parent / "programs" / filename
-        if local_source.exists():
+    if download_text(url, target_path):
+        print(f"[OK] Downloaded latest helper: {filename}")
+        return
+
+    local_source = Path(__file__).resolve().parent / "programs" / filename
+    if local_source.exists():
+        if local_source.resolve() == target_path.resolve():
+            print(f"[SKIP] Local helper already present: {filename}")
+        else:
             shutil.copy2(local_source, target_path)
             print(f"[OK] Download blocked, copied bundled file instead: {filename}")
-        else:
-            print(f"[WARN] Failed to download {filename}: {error}")
+    else:
+        print(f"[WARN] No bundled fallback found for: {filename}")
 
 
 def main() -> None:
     base_path = Path.cwd()
 
-    folders = ["Source", "Output", "programs"]
-    for folder in folders:
+    for folder in ("Source", "Output", "programs", "Additional"):
         ensure_directory(base_path / folder)
-
-    ensure_file(
-        base_path / "README.txt",
-        "Project setup generated by initilization.py\n"
-        f"Release version: v{INITIALIZATION_VERSION}\n",
-    )
-
-    bat_content = "@echo off\npython First.py\npause\n"
-    ensure_file(base_path / "Run Program.bat", bat_content)
 
     programs_path = base_path / "programs"
     for filename, url in PROGRAM_DOWNLOADS.items():
         download_program(programs_path, filename, url)
+
+    if not download_text(README_DOWNLOAD_URL, base_path / "README.txt"):
+        readme_local = Path(__file__).resolve().parent / "README.md"
+        if readme_local.exists():
+            readme_target = base_path / "README.txt"
+            if readme_local.resolve() == readme_target.resolve():
+                print("[SKIP] README.txt already available in current folder")
+            else:
+                shutil.copy2(readme_local, readme_target)
+                print("[OK] Download blocked, copied local README.md into README.txt")
+
+    write_file(base_path / SETUP_BAT_NAME, SETUP_BAT_CONTENT)
+
+    legacy_bat = base_path / "Run Program.bat"
+    if legacy_bat.exists():
+        legacy_bat.unlink()
+        print("[OK] Removed legacy Run Program.bat (replaced by Setup.bat)")
 
     print(f"\nSetup completed (v{INITIALIZATION_VERSION}).")
 


### PR DESCRIPTION
### Motivation
- Simplify and modernize the repository setup so users get a guided, interactive Windows setup flow that refreshes helper scripts and produces a local plaintext README.
- Improve resilience when network downloads are blocked by falling back to bundled helper scripts and avoiding accidental self-copy errors.

### Description
- Replaced `Run Program.bat` with a new interactive `Setup.bat` that explains each step and uses `choice /M` to require user confirmation before continuing, and which creates `Source`, `Output`, `programs`, and `Additional` folders.
- Updated `initilization.py` to version `v0.2`, to generate `Setup.bat`, to download the latest helper scripts from the repository raw URLs with local-file fallbacks and safety checks to avoid copying a file onto itself, and to write `README.md` into `README.txt` when possible.
- Updated `README.md` to reference `Setup.bat` and to describe the interactive setup behavior.
- Appended a changelog entry to `Instructions/Done.txt` per repository agent rules.

### Testing
- Ran `python initilization.py` which completed successfully and exercised fallback logic (network raw downloads were blocked in the environment, so bundled helpers and local README were used); the run finished without errors.
- Ran `python -m py_compile initilization.py First.py programs/check_source_and_extract_to_output.py programs/rename_duplicate_mod_folders.py programs/validate_output_structure.py` and the files compiled successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d8eb920348330950e880dd5ec9d34)