### PR TITLE
Fix Mod_ duplicate detection to use exact post-prefix matching

### DIFF
--- a/Instructions/Done.txt
+++ b/Instructions/Done.txt
@@ -8,3 +8,5 @@
 - Migrated project to pre-bundled portable release layout with shared config-driven Setup/Launch flows, config-aware Python scripts, and tag-triggered GitHub Release zip packaging workflow.
 - Updated .gitignore to ignore instructions/temp-dev folders and lowercase agents.md/readme.md files as requested.
 - Removed deprecated root scripts `First.py` and `initilization.py`, and updated docs/script comments to reflect programs/ as the active workflow.
+- Hardened Launch.bat Python detection to support both `py -3` and `python` and fail fast with clear guidance when Python is missing.
+- Corrected duplicate Mod_ rename logic to compare exact suffixes after `Mod_` across output and rename duplicates by replacing that suffix with a new random 5-character alnum value.

--- a/Launch.bat
+++ b/Launch.bat
@@ -6,15 +6,32 @@ cd /d "%ROOT%"
 
 echo [Launch] FireDragon TOM Modfix
 
+where py >nul 2>nul
+if not errorlevel 1 (
+    set "PYTHON_CMD=py -3"
+) else (
+    where python >nul 2>nul
+    if not errorlevel 1 (
+        set "PYTHON_CMD=python"
+    ) else (
+        echo [ERROR] Python 3 is not installed or not in PATH.
+        echo         Install Python 3.8+ from https://www.python.org/downloads/
+        pause
+        exit /b 1
+    )
+)
+
+echo [INFO] Python command: %PYTHON_CMD%
+
 if not exist "config.json" (
     echo [ERROR] Missing config.json next to Launch.bat.
     pause
     exit /b 1
 )
 
-for /f "usebackq tokens=*" %%I in (`python -c "import json; c=json.load(open('config.json','r',encoding='utf-8')); print(c.get('source_folder','Source'))"`) do set "SOURCE_FOLDER=%%I"
-for /f "usebackq tokens=*" %%I in (`python -c "import json; c=json.load(open('config.json','r',encoding='utf-8')); print(c.get('output_folder','Output'))"`) do set "OUTPUT_FOLDER=%%I"
-for /f "usebackq tokens=*" %%I in (`python -c "import json; c=json.load(open('config.json','r',encoding='utf-8')); print(c.get('main_script','programs/check_source_and_extract_to_output.py'))"`) do set "MAIN_SCRIPT=%%I"
+for /f "usebackq tokens=*" %%I in (`%PYTHON_CMD% -c "import json; c=json.load(open('config.json','r',encoding='utf-8')); print(c.get('source_folder','Source'))"`) do set "SOURCE_FOLDER=%%I"
+for /f "usebackq tokens=*" %%I in (`%PYTHON_CMD% -c "import json; c=json.load(open('config.json','r',encoding='utf-8')); print(c.get('output_folder','Output'))"`) do set "OUTPUT_FOLDER=%%I"
+for /f "usebackq tokens=*" %%I in (`%PYTHON_CMD% -c "import json; c=json.load(open('config.json','r',encoding='utf-8')); print(c.get('main_script','programs/check_source_and_extract_to_output.py'))"`) do set "MAIN_SCRIPT=%%I"
 
 if "%SOURCE_FOLDER%"=="" set "SOURCE_FOLDER=Source"
 if "%OUTPUT_FOLDER%"=="" set "OUTPUT_FOLDER=Output"
@@ -35,8 +52,8 @@ if not exist "%SOURCE_FOLDER%" (
 
 if not exist "%OUTPUT_FOLDER%" mkdir "%OUTPUT_FOLDER%"
 
-echo [RUN ] python "%MAIN_SCRIPT%"
-python "%MAIN_SCRIPT%" "%SOURCE_FOLDER%" "%OUTPUT_FOLDER%"
+echo [RUN ] %PYTHON_CMD% "%MAIN_SCRIPT%"
+%PYTHON_CMD% "%MAIN_SCRIPT%" "%SOURCE_FOLDER%" "%OUTPUT_FOLDER%"
 if errorlevel 1 (
     echo [ERROR] Mod-fix workflow failed.
     pause

--- a/programs/rename_duplicate_mod_folders.py
+++ b/programs/rename_duplicate_mod_folders.py
@@ -1,22 +1,22 @@
 """Task 2:
-Find duplicate Mod_* folders under output and rename extra copies with a random suffix.
+Find duplicate `Mod_` folders under output and rename extra copies.
 
-Duplicate detection is done inside each parent directory. If multiple folders share the same
-base name after stripping a trailing `_<5 alnum chars>` suffix, all but the first are renamed.
+Rules:
+- `Mod_` is a fixed prefix and is never changed.
+- Duplicate comparison is based on the exact suffix after `Mod_` across the output tree.
+- If duplicates are found, all but the first are renamed to `Mod_<random 5 alnum chars>`.
 """
 
 from __future__ import annotations
 
 import argparse
 import random
-import re
 import string
 from pathlib import Path
 
 from shared_config import load_config, root_from_config
 
 MOD_PREFIX = "Mod_"
-SUFFIX_RE = re.compile(r"^(?P<base>.+)_([A-Za-z0-9]{5})$")
 ALNUM = string.ascii_letters + string.digits
 
 
@@ -24,39 +24,32 @@ def random_suffix(length: int = 5) -> str:
     return "".join(random.choices(ALNUM, k=length))
 
 
-def normalized_key(name: str) -> str:
-    if not name.startswith(MOD_PREFIX):
-        return name
-
-    match = SUFFIX_RE.match(name)
-    if not match:
-        return name
-
-    return match.group("base")
+def suffix_after_prefix(name: str) -> str:
+    return name[len(MOD_PREFIX) :]
 
 
 def unique_renamed_path(folder: Path) -> Path:
-    base_name = folder.name
     while True:
-        candidate = folder.with_name(f"{base_name}_{random_suffix(5)}")
+        candidate = folder.with_name(f"{MOD_PREFIX}{random_suffix(5)}")
         if not candidate.exists():
             return candidate
 
 
-def rename_duplicates_in_parent(parent: Path) -> int:
+def rename_duplicates_in_output(output_root: Path) -> int:
     renamed = 0
     groups: dict[str, list[Path]] = {}
 
-    for child in parent.iterdir():
+    mod_folders = [output_root, *output_root.rglob("*")]
+    for child in mod_folders:
         if child.is_dir() and child.name.startswith(MOD_PREFIX):
-            key = normalized_key(child.name)
+            key = suffix_after_prefix(child.name)
             groups.setdefault(key, []).append(child)
 
     for _, folders in groups.items():
         if len(folders) < 2:
             continue
 
-        folders.sort(key=lambda p: p.name)
+        folders.sort(key=lambda p: str(p))
         for duplicate in folders[1:]:
             new_path = unique_renamed_path(duplicate)
             duplicate.rename(new_path)
@@ -71,9 +64,7 @@ def scan_output(output_root: Path) -> int:
         print(f"[ERROR] output root does not exist or is not a folder: {output_root}")
         return 1
 
-    total_renamed = 0
-    for parent in [output_root, *[p for p in output_root.rglob("*") if p.is_dir()]]:
-        total_renamed += rename_duplicates_in_parent(parent)
+    total_renamed = rename_duplicates_in_output(output_root)
 
     print(f"\n=== DONE ===\nTotal renamed folders: {total_renamed}")
     return 0
@@ -81,7 +72,7 @@ def scan_output(output_root: Path) -> int:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Rename duplicate Mod_* folders by appending random 5-char alnum suffixes."
+        description="Rename duplicate Mod_ folders by replacing duplicate suffixes with random 5-char alnum values."
     )
     parser.add_argument("output_root", type=Path, nargs="?", help="Path to output root directory.")
     parser.add_argument("--config", type=Path, default=Path("config.json"), help="Path to shared config file.")


### PR DESCRIPTION
### Motivation
- Ensure `Mod_` is treated as a fixed prefix and duplicate detection compares the exact suffix that follows `Mod_` rather than altering or stripping parts of the base name.
- Handle duplicates consistently across the entire output tree and avoid producing names with stacked suffixes when renaming duplicates.

### Description
- Replaced the previous normalization logic with `suffix_after_prefix` so comparisons use the exact substring after the `Mod_` prefix.
- Updated rename logic so renamed folders are `Mod_<random 5-char alnum>` (replacement), implemented by `unique_renamed_path` using `MOD_PREFIX + random_suffix` instead of appending to the existing name.
- Made duplicate detection operate across the whole output tree via `rename_duplicates_in_output` and kept the first occurrence while renaming additional matches.
- Appended a changelog entry to `Instructions/Done.txt` describing the correction to the `Mod_` duplicate rename logic.

### Testing
- Ran `python programs/rename_duplicate_mod_folders.py --help` and the help printed successfully.
- Created a temporary output tree with duplicate `Mod_same` folders in separate subfolders and ran `python programs/rename_duplicate_mod_folders.py /tmp/modfix-test-output`, which printed a single rename, exited with code `0`, and left exactly one `Mod_same` while renaming the duplicate to `Mod_<random>` as expected.
- All automated assertions in the temporary test passed and the change was recorded in `Instructions/Done.txt`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9781f1bc83308a64985400800467)