### PR TITLE
Add semver release workflow and prepare v0.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,46 @@
-name: Release Portable Setup
+name: Build and Publish Release
 
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
 
 permissions:
   contents: write
 
 jobs:
-  build-release:
+  release:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Prepare release bundle
+      - name: Build portable release bundle
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          BUNDLE_DIR="release-bundle/FireDragon-TOM-Modfix-Setup"
-          mkdir -p "$BUNDLE_DIR"
-          cp -r Source "$BUNDLE_DIR/Source"
-          cp -r Output "$BUNDLE_DIR/Output"
-          cp -r programs "$BUNDLE_DIR/programs"
-          cp Readme.txt Launch.bat Setup.bat config.json "$BUNDLE_DIR/"
 
-      - name: Create zip asset
-        run: |
-          set -euo pipefail
-          cd release-bundle
-          zip -r ../FireDragon-TOM-Modfix-Setup.zip FireDragon-TOM-Modfix-Setup
+          APP_DIR="FireDragon-TOM-Modfix-Setup"
+          BUNDLE_ROOT="release-bundle"
+          ZIP_NAME="FireDragon-TOM-Modfix-Setup-${RELEASE_TAG}.zip"
 
-      - name: Create GitHub release and upload asset
+          rm -rf "$BUNDLE_ROOT" "$ZIP_NAME"
+          mkdir -p "$BUNDLE_ROOT/$APP_DIR"
+
+          cp -r Source "$BUNDLE_ROOT/$APP_DIR/Source"
+          cp -r Output "$BUNDLE_ROOT/$APP_DIR/Output"
+          cp -r programs "$BUNDLE_ROOT/$APP_DIR/programs"
+          cp Readme.txt Launch.bat Setup.bat config.json "$BUNDLE_ROOT/$APP_DIR/"
+
+          cd "$BUNDLE_ROOT"
+          zip -r "../$ZIP_NAME" "$APP_DIR"
+
+      - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: FireDragon-TOM-Modfix-Setup.zip
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true
+          make_latest: true
+          files: FireDragon-TOM-Modfix-Setup-${{ github.ref_name }}.zip

--- a/Instructions/Done.txt
+++ b/Instructions/Done.txt
@@ -10,3 +10,4 @@
 - Removed deprecated root scripts `First.py` and `initilization.py`, and updated docs/script comments to reflect programs/ as the active workflow.
 - Hardened Launch.bat Python detection to support both `py -3` and `python` and fail fast with clear guidance when Python is missing.
 - Corrected duplicate Mod_ rename logic to compare exact suffixes after `Mod_` across output and rename duplicates by replacing that suffix with a new random 5-character alnum value.
+- Added a semantic-version tag workflow that packages the portable setup as a versioned zip and automatically publishes GitHub Releases.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ Edit `config.json` to customize paths and behavior:
 
 All Python scripts in `programs\` read this same shared config.
 
+
+## Maintainer release flow
+
+1. Commit your changes to `main`.
+2. Create and push a semantic version tag (example: `v0.1.0`).
+3. The `Build and Publish Release` workflow builds and uploads `FireDragon-TOM-Modfix-Setup-<tag>.zip` to a GitHub Release.


### PR DESCRIPTION
### Motivation
- Provide a reproducible release pipeline that packages the portable setup and publishes GitHub Releases using semantic version tags so maintainers can ship versioned bundles.
- Document the release flow in the repository to make tagging-and-publishing straightforward for maintainers.

### Description
- Added a GitHub Actions workflow at `.github/workflows/release.yml` that triggers on semantic tags matching `v*.*.*`, builds a portable bundle, creates a versioned zip named `FireDragon-TOM-Modfix-Setup-<tag>.zip`, and publishes a GitHub Release with generated notes and `make_latest` enabled.
- Updated `README.md` with a `Maintainer release flow` section describing the steps to cut and push a semantic version tag for releases.
- Appended a changelog entry to `Instructions/Done.txt` describing the new semantic-version tag workflow and release behavior.

### Testing
- Ran the workflow build steps locally using `RELEASE_TAG=v0.1.0` to verify the bundle and zip creation succeeded and produced `FireDragon-TOM-Modfix-Setup-v0.1.0.zip`.
- Verified the release workflow file and README changes by running local validation steps and ensuring the release packaging step completes without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9a99e38083309af7f27f91795174)