### PR TITLE
Fix release workflow triggers so Actions run before tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,13 @@ name: Build and Publish Release
 
 on:
   push:
+    branches:
+      - main
+      - work
     tags:
       - 'v*.*.*'
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -38,6 +43,7 @@ jobs:
           zip -r "../$ZIP_NAME" "$APP_DIR"
 
       - name: Publish GitHub release
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ github.ref_name }}

--- a/Instructions/Done.txt
+++ b/Instructions/Done.txt
@@ -11,3 +11,4 @@
 - Hardened Launch.bat Python detection to support both `py -3` and `python` and fail fast with clear guidance when Python is missing.
 - Corrected duplicate Mod_ rename logic to compare exact suffixes after `Mod_` across output and rename duplicates by replacing that suffix with a new random 5-character alnum value.
 - Added a semantic-version tag workflow that packages the portable setup as a versioned zip and automatically publishes GitHub Releases.
+- Updated the release workflow triggers so CI runs on branch pushes/PRs/manual dispatch and only publishes GitHub Releases for semantic version tags (v*.*.*).

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ All Python scripts in `programs\` read this same shared config.
 
 ## Maintainer release flow
 
-1. Commit your changes to `main`.
-2. Create and push a semantic version tag (example: `v0.1.0`).
-3. The `Build and Publish Release` workflow builds and uploads `FireDragon-TOM-Modfix-Setup-<tag>.zip` to a GitHub Release.
+1. Open the **Actions** tab and confirm `Build and Publish Release` runs on your branch push/PR (or trigger it manually via `workflow_dispatch`).
+2. Commit your changes to `main`.
+3. Create and push a semantic version tag (example: `v0.1.0`).
+4. Tag pushes matching `v*.*.*` publish `FireDragon-TOM-Modfix-Setup-<tag>.zip` to a GitHub Release.


### PR DESCRIPTION
### Motivation
- The release workflow was only triggering on tag pushes matching `v*.*.*`, so normal commits and pull requests never started the pipeline and it appeared to not run. 
- The intent is to run the build steps on branch pushes/PRs/manual dispatch while still only publishing GitHub Releases for semantic version tags.

### Description
- Updated `.github/workflows/release.yml` to trigger on pushes to `main` and `work`, `pull_request`, and `workflow_dispatch`, and added `if: startsWith(github.ref, 'refs/tags/v')` to the publish step so releases are only created for tag refs. 
- Updated `README.md` maintainer release flow to document the new run behavior and clarify that only `v*.*.*` tags publish releases. 
- Appended the change entry to `Instructions/Done.txt` per repository agent requirements. 
- Changes were committed on branch `work`.

### Testing
- Ran `git diff -- .github/workflows/release.yml README.md Instructions/Done.txt && git status --short` to confirm the expected diffs and workspace state, which succeeded. 
- Performed `git add` (forcing `Instructions/Done.txt`) and `git commit -m "Fix workflow triggers so release pipeline actually runs"`, and the commit completed successfully. 
- Attempted YAML validation with `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/release.yml').read_text())"`, which could not run because `PyYAML` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9c5af9248330bf320bfdc3e338a8)