### PR TITLE
Restrict release publishing to owner-only manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,18 @@
 name: Build and Publish Release
 
 on:
-  push:
-    branches:
-      - main
-      - work
-    tags:
-      - 'v*.*.*'
-  pull_request:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Semantic version tag to release (for example: v1.2.3)'
+        required: true
 
 permissions:
   contents: write
 
 jobs:
   release:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +21,7 @@ jobs:
 
       - name: Build portable release bundle
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.event.inputs.release_tag }}
         run: |
           set -euo pipefail
 
@@ -43,10 +41,10 @@ jobs:
           zip -r "../$ZIP_NAME" "$APP_DIR"
 
       - name: Publish GitHub release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          name: Release ${{ github.ref_name }}
+          tag_name: ${{ github.event.inputs.release_tag }}
+          name: Release ${{ github.event.inputs.release_tag }}
           generate_release_notes: true
           make_latest: true
-          files: FireDragon-TOM-Modfix-Setup-${{ github.ref_name }}.zip
+          files: FireDragon-TOM-Modfix-Setup-${{ github.event.inputs.release_tag }}.zip

--- a/Instructions/Done.txt
+++ b/Instructions/Done.txt
@@ -12,3 +12,4 @@
 - Corrected duplicate Mod_ rename logic to compare exact suffixes after `Mod_` across output and rename duplicates by replacing that suffix with a new random 5-character alnum value.
 - Added a semantic-version tag workflow that packages the portable setup as a versioned zip and automatically publishes GitHub Releases.
 - Updated the release workflow triggers so CI runs on branch pushes/PRs/manual dispatch and only publishes GitHub Releases for semantic version tags (v*.*.*).
+- Updated release workflow to publish only via manual dispatch by the repository owner using a required release_tag input.


### PR DESCRIPTION
### Motivation
- Prevent accidental or automated releases by ensuring publishing only occurs when explicitly triggered by the repository owner. 
- Make the release tag explicit and required to avoid ambiguity in release metadata and artifact naming.

### Description
- Replaced automatic `push`/`pull_request`/tag triggers with `workflow_dispatch` and a required `release_tag` input in `.github/workflows/release.yml`.
- Restricted the `release` job to run only when `github.actor == github.repository_owner` by adding an `if` condition.
- Wired the build and publish steps to use the manual `release_tag` input by setting `RELEASE_TAG`, `tag_name`, release `name`, and artifact filename from `github.event.inputs.release_tag`.
- Appended a changelog entry to `Instructions/Done.txt` describing the workflow change per repository agent rules.

### Testing
- Ran `rg --files .github/workflows` and inspected ` .github/workflows/release.yml` with `sed` to confirm trigger and input changes, which succeeded.
- Verified the workflow diff with `git diff -- .github/workflows/release.yml Instructions/Done.txt` and confirmed the updated lines, which succeeded.
- Checked repository state with `git status --short` and inspected the last change via `git show --stat --oneline HEAD`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da17eaf74833082fdc186d95aaf02)