### PR TITLE
Add helper to flatten single nested Mod_* folders in Output

### DIFF
--- a/Instructions/Done.txt
+++ b/Instructions/Done.txt
@@ -13,3 +13,4 @@
 - Added a semantic-version tag workflow that packages the portable setup as a versioned zip and automatically publishes GitHub Releases.
 - Updated the release workflow triggers so CI runs on branch pushes/PRs/manual dispatch and only publishes GitHub Releases for semantic version tags (v*.*.*).
 - Updated release workflow to publish only via manual dispatch by the repository owner using a required release_tag input.
+- Added programs/flatten_single_nested_mod_folder.py to flatten output subfolders when their only child is a nested Mod_* directory by moving contents up and removing the empty nested folder, and wired Setup.bat to verify/update this helper.

--- a/Setup.bat
+++ b/Setup.bat
@@ -62,7 +62,7 @@ for %%F in ("Readme.txt" "Launch.bat" "Setup.bat" "config.json") do (
     )
 )
 
-for %%P in ("check_source_and_extract_to_output.py" "rename_duplicate_mod_folders.py" "validate_output_structure.py") do (
+for %%P in ("check_source_and_extract_to_output.py" "rename_duplicate_mod_folders.py" "validate_output_structure.py" "flatten_single_nested_mod_folder.py") do (
     if not exist "%PROGRAMS_FOLDER%\%%~P" (
         echo [ERROR] Missing required helper: %PROGRAMS_FOLDER%\%%~P
         set "HAS_ERROR=1"
@@ -78,7 +78,7 @@ goto :finish
 
 :update_tools
 echo [INFO] auto_update_tools enabled. Refreshing helper scripts from GitHub...
-powershell -NoProfile -ExecutionPolicy Bypass -Command "& { $ErrorActionPreference='Stop'; $base='https://raw.githubusercontent.com/FireDragonSlayer/FireDragon-TOM-Modfix/main/programs'; $files=@('check_source_and_extract_to_output.py','rename_duplicate_mod_folders.py','validate_output_structure.py'); foreach ($file in $files) { Invoke-WebRequest -Uri ($base + '/' + $file) -OutFile (Join-Path '%PROGRAMS_FOLDER%' $file); Write-Host ('[OK] Downloaded: ' + $file) } }"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& { $ErrorActionPreference='Stop'; $base='https://raw.githubusercontent.com/FireDragonSlayer/FireDragon-TOM-Modfix/main/programs'; $files=@('check_source_and_extract_to_output.py','rename_duplicate_mod_folders.py','validate_output_structure.py','flatten_single_nested_mod_folder.py'); foreach ($file in $files) { Invoke-WebRequest -Uri ($base + '/' + $file) -OutFile (Join-Path '%PROGRAMS_FOLDER%' $file); Write-Host ('[OK] Downloaded: ' + $file) } }"
 if errorlevel 1 (
     echo [WARN] Tool refresh failed (offline or blocked). Keeping bundled versions.
 )

--- a/programs/flatten_single_nested_mod_folder.py
+++ b/programs/flatten_single_nested_mod_folder.py
@@ -1,0 +1,102 @@
+"""Task 4:
+Flatten output folders that contain only a single nested `Mod_*` folder.
+
+For each direct child folder under output:
+- if its only item is a directory named `Mod_*`, move the contents of that nested
+  folder into the parent folder,
+- then remove the now-empty nested `Mod_*` folder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+from shared_config import load_config, root_from_config
+
+MOD_PREFIX = "Mod_"
+
+
+def move_contents_up(nested_mod_folder: Path, parent_folder: Path) -> tuple[int, int]:
+    moved = 0
+    skipped = 0
+
+    for item in nested_mod_folder.iterdir():
+        target = parent_folder / item.name
+        if target.exists():
+            print(f"  [SKIP] Target already exists: {target}")
+            skipped += 1
+            continue
+
+        shutil.move(str(item), str(target))
+        moved += 1
+
+    return moved, skipped
+
+
+def flatten_output(output_root: Path) -> int:
+    if not output_root.exists() or not output_root.is_dir():
+        print(f"[ERROR] output root does not exist or is not a folder: {output_root}")
+        return 1
+
+    checked = 0
+    flattened = 0
+    moved_items = 0
+    skipped_items = 0
+
+    for folder in output_root.iterdir():
+        if not folder.is_dir():
+            continue
+
+        checked += 1
+        children = list(folder.iterdir())
+        if len(children) != 1:
+            print(f"[SKIP] {folder.name}: expected exactly 1 child, found {len(children)}")
+            continue
+
+        nested = children[0]
+        if not nested.is_dir() or not nested.name.startswith(MOD_PREFIX):
+            print(f"[SKIP] {folder.name}: only child is not a '{MOD_PREFIX}*' folder")
+            continue
+
+        print(f"[FIX ] {folder.name}: flattening nested folder '{nested.name}'")
+        moved, skipped = move_contents_up(nested, folder)
+        moved_items += moved
+        skipped_items += skipped
+
+        if not any(nested.iterdir()):
+            nested.rmdir()
+            flattened += 1
+        else:
+            print(f"  [WARN] Nested folder not empty, not removed: {nested}")
+
+    print("\n=== DONE ===")
+    print(f"Checked folders: {checked}")
+    print(f"Flattened folders: {flattened}")
+    print(f"Moved items: {moved_items}")
+    print(f"Skipped items: {skipped_items}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Flatten output folders where the only child is a nested Mod_* folder."
+    )
+    parser.add_argument("output_root", type=Path, nargs="?", help="Path to output root directory.")
+    parser.add_argument("--config", type=Path, default=Path("config.json"), help="Path to shared config file.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.output_root is not None:
+        output_root = args.output_root
+    else:
+        config = load_config(args.config)
+        output_root = root_from_config(args.config) / config.get("output_folder", "Output")
+    return flatten_output(output_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Some extracted packages place a single `Mod_*` folder one level deeper than expected, leaving an extra nesting level under `Output`; this change flattens that layout automatically.

### Description
- Added `programs/flatten_single_nested_mod_folder.py` which scans each direct child of `Output`, and when a folder has exactly one child directory named `Mod_*`, moves the nested folder's contents up and removes the empty nested folder.
- The script skips items that would conflict with existing files, reports moved/skipped counts, and resolves `output_folder` via the shared `config.json` like the other helpers.
- Updated `Setup.bat` to include `flatten_single_nested_mod_folder.py` in the required helper checks and in the `auto_update_tools` download list.
- Appended a line to `Instructions/Done.txt` to record this major change per the repository agent requirements.

### Testing
- Ran bytecode compilation with `python -m py_compile` for `programs/flatten_single_nested_mod_folder.py` and the existing helper scripts, and compilation succeeded.
- Executed the new helper against a temporary fixture under `temp-dev/agent-test-case/Output` which contained `PackA/Mod_ABC/...` and `PackB/Other/...`; the script moved files from `PackA/Mod_ABC/` into `PackA/` and removed the now-empty nested folder, producing the expected file layout.
- All automated checks performed (compilation and functional run against the temp-dev fixture) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da44b6f448330bb0ebddc7e0a26bc)