### PR TITLE
Run flatten helper automatically during Launch workflow

### DIFF
--- a/Instructions/Done.txt
+++ b/Instructions/Done.txt
@@ -14,3 +14,4 @@
 - Updated the release workflow triggers so CI runs on branch pushes/PRs/manual dispatch and only publishes GitHub Releases for semantic version tags (v*.*.*).
 - Updated release workflow to publish only via manual dispatch by the repository owner using a required release_tag input.
 - Added programs/flatten_single_nested_mod_folder.py to flatten output subfolders when their only child is a nested Mod_* directory by moving contents up and removing the empty nested folder, and wired Setup.bat to verify/update this helper.
+- Updated Launch.bat/config defaults to run the flatten helper automatically after extraction so nested single Mod_* folders are pushed up into each output mod folder.

--- a/Launch.bat
+++ b/Launch.bat
@@ -32,10 +32,12 @@ if not exist "config.json" (
 for /f "usebackq tokens=*" %%I in (`%PYTHON_CMD% -c "import json; c=json.load(open('config.json','r',encoding='utf-8')); print(c.get('source_folder','Source'))"`) do set "SOURCE_FOLDER=%%I"
 for /f "usebackq tokens=*" %%I in (`%PYTHON_CMD% -c "import json; c=json.load(open('config.json','r',encoding='utf-8')); print(c.get('output_folder','Output'))"`) do set "OUTPUT_FOLDER=%%I"
 for /f "usebackq tokens=*" %%I in (`%PYTHON_CMD% -c "import json; c=json.load(open('config.json','r',encoding='utf-8')); print(c.get('main_script','programs/check_source_and_extract_to_output.py'))"`) do set "MAIN_SCRIPT=%%I"
+for /f "usebackq tokens=*" %%I in (`%PYTHON_CMD% -c "import json; c=json.load(open('config.json','r',encoding='utf-8')); print(c.get('flatten_script','programs/flatten_single_nested_mod_folder.py'))"`) do set "FLATTEN_SCRIPT=%%I"
 
 if "%SOURCE_FOLDER%"=="" set "SOURCE_FOLDER=Source"
 if "%OUTPUT_FOLDER%"=="" set "OUTPUT_FOLDER=Output"
 if "%MAIN_SCRIPT%"=="" set "MAIN_SCRIPT=programs/check_source_and_extract_to_output.py"
+if "%FLATTEN_SCRIPT%"=="" set "FLATTEN_SCRIPT=programs/flatten_single_nested_mod_folder.py"
 
 if not exist "%MAIN_SCRIPT%" (
     echo [ERROR] Main script not found: %MAIN_SCRIPT%
@@ -58,6 +60,18 @@ if errorlevel 1 (
     echo [ERROR] Mod-fix workflow failed.
     pause
     exit /b 1
+)
+
+if exist "%FLATTEN_SCRIPT%" (
+    echo [RUN ] %PYTHON_CMD% "%FLATTEN_SCRIPT%"
+    %PYTHON_CMD% "%FLATTEN_SCRIPT%" "%OUTPUT_FOLDER%"
+    if errorlevel 1 (
+        echo [ERROR] Flatten workflow failed.
+        pause
+        exit /b 1
+    )
+) else (
+    echo [WARN] Flatten script not found, skipping: %FLATTEN_SCRIPT%
 )
 
 echo [DONE] Fixed mods are available in "%OUTPUT_FOLDER%".

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Edit `config.json` to customize paths and behavior:
 - `output_folder`
 - `programs_folder`
 - `main_script`
+- `flatten_script`
 - `auto_update_tools`
 - `do_move`
 - `overwrite_files`

--- a/Readme.txt
+++ b/Readme.txt
@@ -7,3 +7,5 @@ FireDragon TOM Modfix (Portable)
 
 Configuration:
 - Edit config.json to change Source/Output/program paths and update behavior.
+
+- Optional: set flatten_script in config.json to control post-processing flatten step.

--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
   "output_folder": "Output",
   "programs_folder": "programs",
   "main_script": "programs/check_source_and_extract_to_output.py",
+  "flatten_script": "programs/flatten_single_nested_mod_folder.py",
   "auto_update_tools": false,
   "do_move": false,
   "overwrite_files": true

--- a/programs/shared_config.py
+++ b/programs/shared_config.py
@@ -10,6 +10,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "output_folder": "Output",
     "programs_folder": "programs",
     "main_script": "programs/check_source_and_extract_to_output.py",
+    "flatten_script": "programs/flatten_single_nested_mod_folder.py",
     "auto_update_tools": False,
     "do_move": False,
     "overwrite_files": True,


### PR DESCRIPTION
### Motivation
- Ensure that nested single `Mod_*` folders created during extraction are flattened automatically so their contents are placed directly in each output mod folder. 
- Make the flatten step configurable and discoverable via `config.json` so it can be enabled/disabled or overridden per deployment.

### Description
- Updated `Launch.bat` to read a new `flatten_script` config value and run the flatten helper after the main extraction step, with error handling when the flatten script fails. 
- Added `flatten_script` to the default config in `programs/shared_config.py` and to the repository `config.json` so the post-process flatten step is enabled by default. 
- Updated documentation in `README.md` and `Readme.txt` to mention the new `flatten_script` option. 
- Appended an entry to `Instructions/Done.txt` to record this change per the repository agent changelog rule.

### Testing
- Ran `python programs/check_source_and_extract_to_output.py temp-dev/_agent_test_source temp-dev/_agent_test_output` to produce an output tree containing nested `Mod_*` payloads, which completed successfully. 
- Ran `python programs/flatten_single_nested_mod_folder.py temp-dev/_agent_test_output` to flatten output folders, which completed successfully. 
- Executed assertions verifying that payload files were moved into their parent output folders and that the nested `Mod_*` folders were removed, and all assertions passed. 
- Temporary `temp-dev` test folders were removed after verification and the changes were committed to the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da6a0d0588330a710cd2ff2f5acba)