### PR TITLE
Exclude Source/Output .gitkeep files from release zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
           cp -r programs "$BUNDLE_ROOT/$APP_DIR/programs"
           cp Readme.txt Launch.bat Setup.bat config.json "$BUNDLE_ROOT/$APP_DIR/"
 
+          rm -f "$BUNDLE_ROOT/$APP_DIR/Source/.gitkeep" "$BUNDLE_ROOT/$APP_DIR/Output/.gitkeep"
+
           cd "$BUNDLE_ROOT"
           zip -r "../$ZIP_NAME" "$APP_DIR"
 

--- a/Instructions/Done.txt
+++ b/Instructions/Done.txt
@@ -15,3 +15,4 @@
 - Updated release workflow to publish only via manual dispatch by the repository owner using a required release_tag input.
 - Added programs/flatten_single_nested_mod_folder.py to flatten output subfolders when their only child is a nested Mod_* directory by moving contents up and removing the empty nested folder, and wired Setup.bat to verify/update this helper.
 - Updated Launch.bat/config defaults to run the flatten helper automatically after extraction so nested single Mod_* folders are pushed up into each output mod folder.
+- Updated release packaging workflow to remove Source/.gitkeep and Output/.gitkeep from generated setup zip bundles.


### PR DESCRIPTION
### Motivation
- Prevent the placeholder `.gitkeep` files in `Source` and `Output` from being included in the generated release ZIP so end users do not receive empty placeholder files in the setup bundle.

### Description
- Updated the release packaging step in `.github/workflows/release.yml` to remove `Source/.gitkeep` and `Output/.gitkeep` from the bundle via `rm -f "$BUNDLE_ROOT/$APP_DIR/Source/.gitkeep" "$BUNDLE_ROOT/$APP_DIR/Output/.gitkeep"` before creating the ZIP, and appended the change to `Instructions/Done.txt` per the repository agent requirements.

### Testing
- Verified the workflow and changelog changes with `git diff -- .github/workflows/release.yml Instructions/Done.txt` which showed the intended modifications and then confirmed the commit with `git show --stat --oneline HEAD`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da8383f5883309349ae658795d164)